### PR TITLE
Fix returned frame size check

### DIFF
--- a/examples/ss_twr_resp/ss_resp_main.c
+++ b/examples/ss_twr_resp/ss_resp_main.c
@@ -121,7 +121,7 @@ int ss_resp_run(void)
 
     /* A frame has been received, read it into the local buffer. */
     frame_len = dwt_read32bitreg(RX_FINFO_ID) & RX_FINFO_RXFL_MASK_1023;
-    if (frame_len <= RX_BUFFER_LEN)
+    if (frame_len <= RX_BUF_LEN)
     {
       dwt_readrxdata(rx_buffer, frame_len, 0);
     }


### PR DESCRIPTION
The returned frame size was being compared with RX_BUFFER_LEN, when it should have been compared with RX_BUF_LEN.

RX_BUF_LEN = 24
RX_BUFFER_LEN = 1024

This was the cause of occasional crashes due to memory being overwritten.